### PR TITLE
Fix QR code missing image/png content type

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -48,10 +48,13 @@ const redirHandler = (request, response) => {
                 return documentSnapshot.ref.update({
                     qrCreateCount: FieldValue.increment(1),
                     qrCreateLast: FieldValue.serverTimestamp()
-                }).then(() => QRCode.toFileStream(
-                    response,
-                    `https://${hostname}/qr${url}`
-                ));
+                }).then(() => {
+                    response.contentType("image/png");
+                    return QRCode.toFileStream(
+                        response,
+                        `https://${hostname}/qr${url}`
+                    );
+                });
             }
             
             if (isRequestViaQrCode) {


### PR DESCRIPTION
## Summary

- `QRCode.toFileStream()` writes PNG data to the Express response stream but never sets the content type, so it defaults to `text/html`
- Browsers receive valid PNG bytes but try to render them as HTML, resulting in a broken page
- Fix: set `response.contentType("image/png")` before streaming the QR code

## Test plan

- [ ] `curl -s -o /dev/null -w '%{content_type}' https://qr.scj.io/desk` returns `image/png` after deploy
- [ ] QR code renders as an image in browser at `qr.scj.io/desk`

🤖 Generated with [Claude Code](https://claude.com/claude-code)